### PR TITLE
Set OpenAI Key

### DIFF
--- a/.cz.toml
+++ b/.cz.toml
@@ -2,6 +2,6 @@
 name = "cz_conventional_commits"
 tag_format = "$version"
 version_scheme = "semver"
-version = "1.0.0"
+version = "1.1.0"
 update_changelog_on_bump = true
 major_version_zero = true

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 setup(
     name="strava-to-trainingpeaks",
-    version="1.0.0",
+    version="1.1.0",
     author="Lucas de Brito Silva",
     author_email="lucasbsilva29@gmail.com",
     description="A tool to sync Strava activities with TrainingPeaks, with the OpenAI API creating the workout descriptions.",

--- a/src/main.py
+++ b/src/main.py
@@ -60,6 +60,7 @@ def main():
             logger.info("Validating the TCX file")
             _, tcx_data = validate_tcx_file(file_path)
             if ask_llm_analysis():
+                check_key()
                 plan = ask_training_plan()
                 language = ask_desired_language()
                 logger.info("Performing LLM analysis")
@@ -94,7 +95,8 @@ def ask_activity_id() -> str:
 
 
 def download_tcx_file(activity_id: str, sport: str) -> None:
-    url = f"https://www.strava.com/activities/{activity_id}/export_{'original' if sport in ['Swim', 'Other'] else 'tcx'}"
+    url = f"https://www.strava.com/activities/{activity_id}/export_{
+        'original' if sport in ['Swim', 'Other'] else 'tcx'}"
     try:
         webbrowser.open(url)
     except Exception as err:
@@ -200,6 +202,17 @@ def ask_desired_language() -> str:
         "In which language do you want the analysis to be provided? (Default is Portuguese)",
         default="Portuguese (Brazil)"
     ).ask()
+
+
+def check_key() -> None:
+    if not os.getenv("OPENAI_API_KEY"):
+        openai_key = questionary.text(
+            "Enter your OpenAI API key:"
+        ).ask()
+        with open(".env", "w") as env_file:
+            env_file.write(f"OPENAI_API_KEY={openai_key}")
+        load_dotenv()
+        logger.info("OpenAI API key loaded successfully.")
 
 
 def perform_llm_analysis(data: TCXReader, sport: str, plan: str, language: str) -> str:

--- a/src/main.py
+++ b/src/main.py
@@ -60,7 +60,7 @@ def main():
             logger.info("Validating the TCX file")
             _, tcx_data = validate_tcx_file(file_path)
             if ask_llm_analysis():
-                check_key()
+                check_openai_key()
                 plan = ask_training_plan()
                 language = ask_desired_language()
                 logger.info("Performing LLM analysis")
@@ -204,7 +204,7 @@ def ask_desired_language() -> str:
     ).ask()
 
 
-def check_key() -> None:
+def check_openai_key() -> None:
     if not os.getenv("OPENAI_API_KEY"):
         openai_key = questionary.text(
             "Enter your OpenAI API key:"

--- a/src/main.py
+++ b/src/main.py
@@ -206,7 +206,7 @@ def ask_desired_language() -> str:
 
 def check_openai_key() -> None:
     if not os.getenv("OPENAI_API_KEY"):
-        openai_key = questionary.text(
+        openai_key = questionary.password(
             "Enter your OpenAI API key:"
         ).ask()
         with open(".env", "w") as env_file:

--- a/src/main.py
+++ b/src/main.py
@@ -209,7 +209,7 @@ def check_openai_key() -> None:
         openai_key = questionary.password(
             "Enter your OpenAI API key:"
         ).ask()
-        with open(".env", "w") as env_file:
+        with open(".env", "w", encoding="utf-8") as env_file:
             env_file.write(f"OPENAI_API_KEY={openai_key}")
         load_dotenv()
         logger.info("OpenAI API key loaded successfully.")

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -147,6 +147,7 @@ class TestMain(unittest.TestCase):
 
         self.assertTrue(mock_parse_string.called)
 
+    @patch('src.main.check_openai_key')
     @patch('src.main.get_latest_download')
     @patch('src.main.ask_sport')
     @patch('src.main.ask_file_location')
@@ -156,11 +157,12 @@ class TestMain(unittest.TestCase):
     @patch('src.main.validate_tcx_file')
     @patch('src.main.indent_xml_file')
     def test_main(self, mock_indent, mock_validate, mock_format, mock_download, mock_ask_id,
-                  mock_ask_location, mock_ask_sport, mock_latest_download):
+                  mock_ask_location, mock_ask_sport, mock_latest_download, mock_openai_key):
         mock_ask_sport.return_value = "Swim"
         mock_ask_location.return_value = "Download"
         mock_ask_id.return_value = "12345"
         mock_latest_download.return_value = "assets/swim.tcx"
+        mock_openai_key.return_value = None
 
         main()
 
@@ -173,6 +175,7 @@ class TestMain(unittest.TestCase):
         mock_validate.assert_not_called()
         mock_indent.assert_called_once_with("assets/swim.tcx")
 
+    @patch('src.main.check_openai_key')
     @patch('src.main.ask_sport')
     @patch('src.main.ask_file_location')
     @patch('src.main.ask_activity_id')
@@ -182,7 +185,8 @@ class TestMain(unittest.TestCase):
     @patch('src.main.validate_tcx_file')
     @patch('src.main.indent_xml_file')
     def test_main_invalid_sport(self, mock_indent, mock_validate, mock_format, mock_latest_download, mock_download,
-                                mock_ask_id, mock_ask_location, mock_ask_sport):
+                                mock_ask_id, mock_ask_location, mock_ask_sport, mock_openai_key):
+        mock_openai_key.return_value = None
         mock_ask_sport.return_value = "InvalidSport"
         mock_ask_location.return_value = "Download"
         mock_ask_id.return_value = "12345"
@@ -200,6 +204,7 @@ class TestMain(unittest.TestCase):
         mock_validate.assert_not_called()
         mock_indent.assert_not_called()
 
+    @patch('src.main.check_openai_key')
     @patch('src.main.ask_desired_language')
     @patch('src.main.ask_training_plan')
     @patch('src.main.perform_llm_analysis')
@@ -214,7 +219,7 @@ class TestMain(unittest.TestCase):
     @patch('src.main.indent_xml_file')
     def test_main_bike_sport(self, mock_indent, mock_validate, mock_format, mock_ask_path, mock_download,
                              mock_ask_id, mock_ask_location, mock_ask_sport, mock_llm_analysis, mock_perform_llm,
-                             mock_training_plan, mock_language):
+                             mock_training_plan, mock_language, mock_openai_key):
         mock_ask_sport.return_value = "Bike"
         mock_ask_location.return_value = "Local"
         mock_ask_path.return_value = "assets/bike.tcx"
@@ -223,6 +228,7 @@ class TestMain(unittest.TestCase):
         mock_perform_llm.return_value = "Training Plan"
         mock_training_plan.return_value = ""
         mock_language.return_value = "Portuguese"
+        mock_openai_key.return_value = None
 
         main()
 


### PR DESCRIPTION
This change is related to making life easier for users who do not have their OpenAI key linked to the project, as the documentation indicates. Often, users may not read the documentation and our goal is to make life easier for these users, so that they do not interrupt the execution to be able to define their key and have their detailed analysis, but rather that they have a complete experience so that the application itself makes it easier to use.

Enhancements to functionality:

* Added a new function `check_key()` to verify if the `OPENAI_API_KEY` environment variable is set. If not, it prompts the user to enter the key and saves it to a `.env` file. (`src/main.py`)
* Updated the `main()` function to call `check_key()` before performing LLM analysis. (`src/main.py`)

Improvements to code readability:

* Modified the `download_tcx_file()` function to use multi-line string formatting for the URL. (`src/main.py`)